### PR TITLE
Update gpu_usage.sh

### DIFF
--- a/system-monitor-next@paradoxxx.zero.gmail.com/gpu_usage.sh
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/gpu_usage.sh
@@ -31,13 +31,21 @@ if checkcommand nvidia-smi; then
 	nvidia-smi -i 0 --query-gpu=memory.total,memory.used,utilization.gpu --format=csv,noheader,nounits | while IFS=', ' read -r a b c; do echo "$a"; echo "$b"; echo "$c"; done
 
 elif lsmod | grep amdgpu > /dev/null; then
-	total=$(cat /sys/class/drm/card0/device/mem_info_vram_total)
+	# Set `card0` or `card1` here. For some reason `card1` might be used instead.
+ 	# This could have something to do with Ryzen integrated GPUs.
+ 	# There could be a drop down selector in the UI.
+ 	if [ -e /sys/class/drm/card0 ]; then
+  		card=card0
+    	else
+     		card=card1
+       	fi
+	total=$(cat /sys/class/drm/$card/device/mem_info_vram_total)
 	echo $(($total / 1024 / 1024))
 
-	used=$(cat /sys/class/drm/card0/device/mem_info_vram_used)
+	used=$(cat /sys/class/drm/$card/device/mem_info_vram_used)
 	echo $(($used / 1024 / 1024))
 
-	cat /sys/class/drm/card0/device/gpu_busy_percent
+	cat /sys/class/drm/$card/device/gpu_busy_percent
 
 elif checkcommand glxinfo; then
 	TOTALVRAM=$(glxinfo | grep -A2 -i GL_NVX_gpu_memory_info | grep -E -i 'dedicated')


### PR DESCRIPTION
Hey, I've come with a minor issue when the script attempted to access `cat /sys/class/drm/card0/[...]` while `card0` did not exist for some reason and `card1` was used instead. I've provided the fix locally in `gpu_usage.sh`:

```
elif lsmod | grep amdgpu > /dev/null; then
        # FIX `card1` instead of `card0` not existing
        card=card1
        total=$(cat /sys/class/drm/$card/device/mem_info_vram_total)
        echo $(($total / 1024 / 1024))

        used=$(cat /sys/class/drm/$card/device/mem_info_vram_used)
        echo $(($used / 1024 / 1024))

        cat /sys/class/drm/$card/device/gpu_busy_percent
```

And voilà. Maybe there could be a drop-down menu looking for `deviceX`  in `/sys/class/drm` but I didn't look this one up yet. As added in the comments later this might have something to do with Ryzen integrated GPUs but I'm not sure right now.